### PR TITLE
Added exception in  set_pub_year_month_day for publications that do n…

### DIFF
--- a/pubmed_lookup/pubmed_lookup.py
+++ b/pubmed_lookup/pubmed_lookup.py
@@ -201,7 +201,7 @@ class Publication(object):
             try:
                 self.month = datetime.datetime.strptime(
                     month_short, "%b").month
-            except ValueError:
+            except (ValueError, TypeError) as e:
                 self.month = ''
 
         else:


### PR DESCRIPTION
Running PubMedLookup on 25156302 returns a proper object. Passing that object to Publication raises an uncaught TypeError as follows

```
>>> r = PubMedLookup(25156302, 'email')
>>> Publication(r)
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/scuerda/Projects/timi/lib/python3.4/site-packages/pubmed_lookup/pubmed_lookup.py", line 41, in __init__
    self.set_pub_year_month_day(xml_dict)
  File "/home/scuerda/Projects/timi/lib/python3.4/site-packages/pubmed_lookup/pubmed_lookup.py", line 203, in set_pub_year_month_day
    month_short, "%b").month
TypeError: must be str, not None
```

Added TypeError to exception handling, which properly handles missing month.
