### PR TITLE
Prevent http.client.InvalidURL exception on set_article_url()

### DIFF
--- a/pubmed_lookup/pubmed_lookup.py
+++ b/pubmed_lookup/pubmed_lookup.py
@@ -184,7 +184,7 @@ class Publication(object):
         If record has a DOI, set article URL based on where the DOI points.
         """
         if 'DOI' in self.record:
-            doi_url = "/".join(['http://dx.doi.org', self.record['DOI']])
+            doi_url = "/".join(['http://dx.doi.org', ''.join(self.record['DOI'].split())])
 
             if resolve_doi:
                 try:


### PR DESCRIPTION
Hi @mfcovington!
I came across an uncaught "http.client.InvalidURL: URL can't contain control characters" exception while running pubmed-lookup on a project.
The issue was caused by a weird record['DOI'] string containing a whitespace (PMID: 31207675). The error can be reproduced running the code below:
```
from pubmed_lookup import PubMedLookup, Publication
email = ''
pmid = '31207675'
lookup = PubMedLookup(pmid, email)
publication = Publication(lookup, resolve_doi=True)
```

I've added some split() and join() to set_article_url() method to remove whitespace characters from URLs. I don't think this is such a common issue, but I hope this change can help.