### PR TITLE
Allow user to provide kwargs to Entrez

### DIFF
--- a/pubmed_lookup/pubmed_lookup.py
+++ b/pubmed_lookup/pubmed_lookup.py
@@ -230,12 +230,13 @@ class PubMedLookup(object):
     (e.g., '22331878' or 'http://www.ncbi.nlm.nih.gov/pubmed/22331878')
     """
 
-    def __init__(self, query, user_email):
+    def __init__(self, query, user_email, **kwargs):
         """
         Upon init: set email as required by API, determine whether query
         is PubMed ID or PubMed URL and retrieve PubMed record accordingly.
         """
         Entrez.email = user_email
+        Entrez.__dict__.update(kwargs)
 
         pmid_pattern = r'^\d+$'
         pmurl_pattern = r'^https?://www\.ncbi\.nlm\.nih\.gov/pubmed/\d+$'


### PR DESCRIPTION
A small tweak that allows the user to provide `kwargs` to `PubmedLookup` which will be passed to `Entrez`.

My motivation was that I wanted to provide my personal `api_key` to up the request rate limit from 3/sec to 10/sec (see [here](https://www.ncbi.nlm.nih.gov/books/NBK25497/)). This solution is nice because it allows the user to set any of the arguments of `Entrez`, not just `api_key`.